### PR TITLE
Storeをlocal storageに保存して永続化する

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -47,6 +47,10 @@ module.exports = {
     baseURL: envSet.apiBaseUrl,
     credentials: true
   },
-  plugins: ['~/plugins/axios']
+  plugins: [
+    '~/plugins/axios',
+    { src: '~/plugins/local-storage', ssr: false },
+  ],
+  mode: 'spa'
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8985,6 +8985,11 @@
         "jsonify": "0.0.0"
       }
     },
+    "shvl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-1.3.1.tgz",
+      "integrity": "sha512-+rRPP46hloYUAEImJcqprUgXu+05Ikqr4h4V+w5i2zJy37nAqtkQKufs3+3S2fDq6JNRrHMIQhB/Vaex+jgAAw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -10054,6 +10059,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
       "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
+    },
+    "vuex-persistedstate": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.5.4.tgz",
+      "integrity": "sha512-XYJhKIwO+ZVlTaXyxKxnplrJ88Fnvk5aDw753bxzRw5/yMKLQ6lq9CDCBex2fwZaQcLibhtgJOxGCHjy9GLSlQ==",
+      "requires": {
+        "deepmerge": "2.1.1",
+        "shvl": "1.3.1"
+      }
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@nuxtjs/axios": "^5.3.1",
     "@nuxtjs/vuetify": "^0.4.2",
     "nuxt": "^1.0.0",
-    "vue-infinite-loading": "^2.3.1"
+    "vue-infinite-loading": "^2.3.1",
+    "vuex-persistedstate": "^2.5.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",

--- a/plugins/local-storage.js
+++ b/plugins/local-storage.js
@@ -1,0 +1,5 @@
+import createPersistedState from "vuex-persistedstate";
+
+export default ({store}) => {
+    createPersistedState()(store); // vuex plugins can be connected to store, even after creation
+};


### PR DESCRIPTION
* [Express \- Nuxt\.js passport、vuex\-persistedstateを使ったログイン認証でリロードするとミドルウェア時に読み込めていない\(123816\)｜teratail](https://teratail.com/questions/123816)
* [Nuxt\.jsでlocalStorageを用いる際のTipsとハマったこと \- Qiita](https://qiita.com/sunecosuri/items/3544fb101cabd310acc3)
* [nuxt\.jsを使う時にlocalStorageでstoreを永続化する \- Qiita](https://qiita.com/sakapun/items/a0cf5698751ae70c8088)