### PR TITLE
Nuxtモジュールのvuetifyからオリジナルのvuetifyパッケージに変更

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,7 +8,7 @@
       <v-list dense>
         <v-list-tile @click="$router.push('/')">
           <v-list-tile-action>
-            <v-icon>list_alt</v-icon>
+            <v-icon>subject</v-icon>
           </v-list-tile-action>
           <v-list-tile-content>
             <v-list-tile-title>Article</v-list-tile-title>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -39,7 +39,6 @@ module.exports = {
     },
   },
   modules: [
-    '@nuxtjs/vuetify',
     '@nuxtjs/axios',
   ],
   env: envSet,
@@ -49,6 +48,7 @@ module.exports = {
   },
   plugins: [
     '~/plugins/axios',
+    '~/plugins/vuetify',
     { src: '~/plugins/local-storage', ssr: false },
   ],
   mode: 'spa'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5092,6 +5092,12 @@
         "object-visit": "1.0.1"
       }
     },
+    "material-design-icons-iconfont": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-3.0.3.tgz",
+      "integrity": "sha1-FUoQhAR9Ticjf6f1o34Qdc7qbfI=",
+      "dev": true
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10042,6 +10042,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
     },
+    "vuetify": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.2.3.tgz",
+      "integrity": "sha512-ssMsLVwth62T4usPAFbn8yk69qqBDp4VWPmlY4XiYZ7aGMPoa/sQ08BlAeG8J81y+K60bY88FZ2gquQKlGqlsg=="
+    },
     "vuex": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,14 +171,6 @@
         "http-proxy-middleware": "0.18.0"
       }
     },
-    "@nuxtjs/vuetify": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/vuetify/-/vuetify-0.4.2.tgz",
-      "integrity": "sha1-kdpMwlRXNJ8AE0ktN0Mpp4AN32k=",
-      "requires": {
-        "vuetify": "1.1.8"
-      }
-    },
     "@nuxtjs/youch": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@nuxtjs/youch/-/youch-4.2.3.tgz",
@@ -10049,11 +10041,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
-    },
-    "vuetify": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.1.8.tgz",
-      "integrity": "sha512-22PQGO/GfO8FG45G9Yz1CISZ4AD3i8XFvAVNuoiJ9vCXZYIevLlMPwx73PTOhZxmfgCC0z+gfWwnLOkPpEUlAQ=="
     },
     "vuex": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@nuxtjs/axios": "^5.3.1",
     "nuxt": "^1.0.0",
     "vue-infinite-loading": "^2.3.1",
+    "vuetify": "^1.2.3",
     "vuex-persistedstate": "^2.5.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^4.15.0",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",
-    "eslint-plugin-vue": "^4.0.0"
+    "eslint-plugin-vue": "^4.0.0",
+    "material-design-icons-iconfont": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.3.1",
-    "@nuxtjs/vuetify": "^0.4.2",
     "nuxt": "^1.0.0",
     "vue-infinite-loading": "^2.3.1",
     "vuex-persistedstate": "^2.5.4"

--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -1,5 +1,7 @@
+
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
+import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
 Vue.use(Vuetify);

--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -1,0 +1,5 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import 'vuetify/dist/vuetify.min.css'
+
+Vue.use(Vuetify);


### PR DESCRIPTION
Nuxtモジュールのvuetifyだとバージョンアップが遅れているので、オリジナル側を利用してバージョンをコントロールできるようにする